### PR TITLE
APBN-1828: fix requiresMainQueueSetup warning

### DIFF
--- a/ios/AppboosterSdkReactNative.m
+++ b/ios/AppboosterSdkReactNative.m
@@ -2,6 +2,11 @@
 
 @interface RCT_EXTERN_MODULE(AppboosterSdkReactNative, NSObject)
 
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
+}
+
 RCT_EXTERN_METHOD(connect:(NSDictionary *)sdkSettings
                  withResolver:(RCTPromiseResolveBlock)resolve
                  withRejecter:(RCTPromiseRejectBlock)reject)


### PR DESCRIPTION
#### :tophat: Что? Зачем?
Фикс варнинга "requires main queue setup since it overrides `init` but doesn't implement `requiresMainQueueSetup`"

#### 📌 Задачи
https://appbooster.atlassian.net/browse/APBN-1828