### PR TITLE
APBN-1828: fix experiments values getting

### DIFF
--- a/android/src/main/java/com/appboostersdkreactnative/AppboosterSdkReactNativeModule.kt
+++ b/android/src/main/java/com/appboostersdkreactnative/AppboosterSdkReactNativeModule.kt
@@ -55,7 +55,12 @@ class AppboosterSdkReactNativeModule(reactContext: ReactApplicationContext) : Re
 
     @ReactMethod
     fun getExperiments(addAppboosterPrefix: Boolean, promise: Promise) {
-        promise.resolve(Utils.prepareExperimentsForJS(sdk!!.getExperiments(withPrefix = addAppboosterPrefix)))
+        val experiments = mutableMapOf<String, String>()
+        for((key, _) in sdk!!.getExperiments(withPrefix = addAppboosterPrefix)) {
+            val experimentValue = sdk!![key] as String
+            experiments[key] = experimentValue
+        }
+        promise.resolve(Utils.prepareExperimentsForJS(experiments))
     }
 
     @ReactMethod

--- a/ios/AppboosterSdkReactNative.swift
+++ b/ios/AppboosterSdkReactNative.swift
@@ -46,7 +46,12 @@ class AppboosterSdkReactNative: NSObject {
         addAppboosterPrefix: Bool,
         resolve: @escaping RCTPromiseResolveBlock,
         reject: @escaping RCTPromiseRejectBlock) -> Void {
-        resolve(sdk!.experiments(addAppboosterPrefix: addAppboosterPrefix))
+        var experiments: [String: String] = [:]
+        for (key, _) in sdk!.experiments(addAppboosterPrefix: addAppboosterPrefix) {
+            let experimentValue: String? = sdk[key]
+            experiments.updateValue(experimentValue ?? "", forKey: key)
+        }
+        resolve(experiments)
     }
     
     @objc(getLastOperationDurationMillis:withRejecter:)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appbooster-sdk-react-native",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Mobile framework for Appbooster platform.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
#### :tophat: Что? Зачем?
При внедрении SDK в один из проектов выяснилось следующее:
`let experiments = ab.experiments()` всегда возвращает список экспериментов с их начальными значениями, определенными для юзера при установке приложения, вне зависимости от того, какое значение выставлено в debug-меню для того или иного эксперимента.
Однако при получении значения через обращение к конкретному эксперименту `ab["<TEST_KEY>"]` мы получаем значение эксперимента, выставленное в debug-меню.
До исправления проблемы на стороне нативных SDK вношу фикс в логику получения корректных значений экспериментов - бежим по списку экспериментов, но значение для того или иного названия эксперимента получаем не из списка экспериментов, а путем обращения к sdk (`ab["<TEST_KEY>"]`).

#### 📌 Задачи
https://appbooster.atlassian.net/browse/APBN-1828