### PR TITLE
fix: appsflyerId parsing on android side

### DIFF
--- a/android/src/main/java/com/appboostersdkreactnative/AppboosterSdkReactNativeModule.kt
+++ b/android/src/main/java/com/appboostersdkreactnative/AppboosterSdkReactNativeModule.kt
@@ -21,7 +21,7 @@ class AppboosterSdkReactNativeModule(reactContext: ReactApplicationContext) : Re
         val usingShake = preparedSettings.getBoolean("usingShake")
         val defaults = Utils.getDefaultExperiments(preparedSettings.getJSONObject("defaults"))
         val showLogs = preparedSettings.getBoolean("showLogs")
-        val appsFlyerId = if (preparedSettings.has("appsFlyerId ")) preparedSettings.getString("appsFlyerId") else null
+        val appsFlyerId = if (preparedSettings.has("appsFlyerId")) preparedSettings.getString("appsFlyerId") else null
 
         if (currentActivity != null) {
             currentActivity!!.runOnUiThread(Runnable {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appbooster-sdk-react-native",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Mobile AB-testing SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
#### :tophat: Что? Зачем?
- Фикс ошибки парсинга параметра `appsFlyerId` на стороне android'а
-  Заинкрементил версию RN SDK