### PR TITLE
feat: update android sdk to 0.5.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -127,5 +127,5 @@ dependencies {
   // noinspection GradleDynamicVersion
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.appbooster.appboostersdk:appboostersdk:0.5.0"
+  implementation "com.appbooster.appboostersdk:appboostersdk:0.5.1"
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - appbooster-sdk-react-native (0.2.7):
+  - appbooster-sdk-react-native (0.2.8):
     - AppboosterSDK (= 0.2.6)
     - React
   - AppboosterSDK (0.2.6)
@@ -407,7 +407,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  appbooster-sdk-react-native: 897d5c285db135cf12e6c641b4080f0578220e5d
+  appbooster-sdk-react-native: 1312c4c9cd9f9e6c670afd83caa7532e7b06bc4a
   AppboosterSDK: 87a2ce8e780dfd81996d229127a205bcd36e8ced
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appbooster-sdk-react-native",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Mobile AB-testing SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
#### :tophat: Что? Зачем?
Обновляем версию для android sdk на 0.5.1. В данной версии исправлена [логика обработки ошибок при запросе экспериментов](https://github.com/appbooster/appbooster-sdk-android/pull/14).

